### PR TITLE
Distribute as ES5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "optional": [
-    "es7.decorators"
-  ]
+  presets: ['env'],
+  plugins: ['transform-decorators-legacy']
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: node_js
 node_js:
-- iojs
+  - '4'
+  - '6'
 deploy:
   provider: npm
   email: bvdrucker@gmail.com

--- a/README.md
+++ b/README.md
@@ -10,14 +10,19 @@ $ npm install angular-annotation-decorator
 ## Usage
 
 ```js
-import {annotate} from 'angular-annotation-decorator';
+import inject from 'angular-annotation-decorator';
 
-@annotate('$http', '$q')
+@inject('$http', '$q')
 class MyService {
   constructor ($http, $q) {
-    // 
+    //
+  }
+
+  @inject('$log')
+  method ($log) {
+    //
   }
 }
 ```
 
-You'll need to use an ESNext transpiler like [Babel](https://babeljs.io/) and [enable the experimental `es7.decorators` transformer](http://babeljs.io/docs/usage/experimental/).
+You'll need to use an ESNext transpiler like [Babel](https://babeljs.io/) and [enable support for decorators](https://www.npmjs.com/package/babel-plugin-transform-decorators-legacy).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "ES7 decorator for adding $inject annotations for Angular 1.x",
   "main": "./src",
+  "files": [
+    "src/"
+  ],
   "directories": {
     "test": "test"
   },
@@ -16,9 +19,11 @@
   "keywords": [
     "angular",
     "annotate",
-    "es7",
     "babel",
-    "experimental"
+    "decorator",
+    "es7",
+    "experimental",
+    "inject"
   ],
   "author": "Ben Drucker <bvdrucker@gmail.com> (http://www.bendrucker.me/)",
   "license": "MIT",
@@ -27,16 +32,10 @@
   },
   "homepage": "https://github.com/bendrucker/angular-annotation-decorator",
   "devDependencies": {
-    "babel": "~5.0.12",
-    "babel-tape-runner": "~1.1.0",
-    "tape": "~4.0.0"
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-env": "^1.4.0",
+    "babel-tape-runner": "^2.0.1",
+    "tape": "^4.6.3"
   },
-  "dependencies": {
-    "babelify": "~6.0.2"
-  },
-  "browserify": {
-    "transform": [
-      "babelify"
-    ]
-  }
+  "dependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
-export function annotate (...services) {
+var slice = [].slice;
+
+module.exports = function annotate () {
+  var services = slice.call(arguments);
   return function decorate (target, key, descriptor) {
     if (descriptor) target = descriptor.value;
     target.$inject = services;

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
 import test from 'tape';
-import {annotate} from '../';
+import inject from '../';
 
 test((t) => {
 
-  @annotate('b', 'c')
+  @inject('b', 'c')
   class A {}
   t.deepEqual(A.$inject, ['b', 'c'], 'class');
 
   class B {
-    @annotate('a')
+    @inject('a')
     method () {}
   }
   t.deepEqual(B.prototype.method.$inject, ['a'], 'method');


### PR DESCRIPTION
Fixes #2.

In addition, this PR:
    
* [BREAKING CHANGE] uses a default export so the user can succinctly specify the decorator's name (e.g. `inject`) <s>(support for the old usage is maintained for backwards compatibility)</s>
* <s>separates the distributed file (dist/index.js) from the source file (src/index.js)</s>
* runs tests on <s>each major Node version</s>  each LTS version
* updates the dependencies
* adds more search keywords